### PR TITLE
Fix Mouse wheel conflict with Xbuttons 1&2

### DIFF
--- a/src/i_input.c
+++ b/src/i_input.c
@@ -317,6 +317,8 @@ static void UpdateMouseButtonState(unsigned int button, boolean on)
     // Note: button "0" is left, button "1" is right,
     // button "2" is middle for Doom.  This is different
     // to how SDL sees things.
+    // In the end: Left=0, Right=1, Middle=2,
+    // WheelUp=3 WheelDown=4, XButton1=5, XButton2=6
 
     switch (button)
     {
@@ -334,7 +336,9 @@ static void UpdateMouseButtonState(unsigned int button, boolean on)
 
         default:
             // SDL buttons are indexed from 1.
-            --button;
+            // And the wheel is mapped to button 3/4
+            // So we have to increment 2 and decrement 1 => inc 1.
+            button++;
             break;
     }
 
@@ -367,11 +371,11 @@ static void MapMouseWheelToButtons(SDL_MouseWheelEvent *wheel)
 
     if (wheel->y <= 0)
     {   // scroll down
-        button = 7;
+        button = 4;
     }
     else
     {   // scroll up
-        button = 6;
+        button = 3;
     }
 
     // post a button down event

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -367,11 +367,11 @@ static void MapMouseWheelToButtons(SDL_MouseWheelEvent *wheel)
 
     if (wheel->y <= 0)
     {   // scroll down
-        button = 4;
+        button = 7;
     }
     else
     {   // scroll up
-        button = 3;
+        button = 6;
     }
 
     // post a button down event

--- a/src/setup/txt_mouseinput.c
+++ b/src/setup/txt_mouseinput.c
@@ -84,6 +84,12 @@ static void GetMouseButtonDescription(int button, char *buf, size_t buf_len)
         case 2:
             M_StringCopy(buf, "MID", buf_len);
             break;
+        case 6:
+            M_StringCopy(buf, "WHEEL UP", buf_len);
+            break;
+        case 7:
+            M_StringCopy(buf, "WHEEL DOWN", buf_len);
+            break;
         default:
             M_snprintf(buf, buf_len, "BUTTON #%i", button + 1);
             break;

--- a/src/setup/txt_mouseinput.c
+++ b/src/setup/txt_mouseinput.c
@@ -84,14 +84,14 @@ static void GetMouseButtonDescription(int button, char *buf, size_t buf_len)
         case 2:
             M_StringCopy(buf, "MID", buf_len);
             break;
-        case 6:
+        case 3:
             M_StringCopy(buf, "WHEEL UP", buf_len);
             break;
-        case 7:
+        case 4:
             M_StringCopy(buf, "WHEEL DOWN", buf_len);
             break;
         default:
-            M_snprintf(buf, buf_len, "BUTTON #%i", button + 1);
+            M_snprintf(buf, buf_len, "BUTTON #%i", button - 1);
             break;
     }
 }

--- a/textscreen/txt_main.h
+++ b/textscreen/txt_main.h
@@ -41,8 +41,8 @@
 #define TXT_MOUSE_LEFT         (TXT_MOUSE_BASE + 0)
 #define TXT_MOUSE_RIGHT        (TXT_MOUSE_BASE + 1)
 #define TXT_MOUSE_MIDDLE       (TXT_MOUSE_BASE + 2)
-#define TXT_MOUSE_SCROLLUP     (TXT_MOUSE_BASE + 6)
-#define TXT_MOUSE_SCROLLDOWN   (TXT_MOUSE_BASE + 7)
+#define TXT_MOUSE_SCROLLUP     (TXT_MOUSE_BASE + 3)
+#define TXT_MOUSE_SCROLLDOWN   (TXT_MOUSE_BASE + 4)
 #define TXT_MAX_MOUSE_BUTTONS  16
 
 #define TXT_KEY_TO_MOUSE_BUTTON(x)                                        \

--- a/textscreen/txt_main.h
+++ b/textscreen/txt_main.h
@@ -43,6 +43,8 @@
 #define TXT_MOUSE_MIDDLE       (TXT_MOUSE_BASE + 2)
 #define TXT_MOUSE_SCROLLUP     (TXT_MOUSE_BASE + 3)
 #define TXT_MOUSE_SCROLLDOWN   (TXT_MOUSE_BASE + 4)
+#define TXT_MOUSE_X1           (TXT_MOUSE_BASE + 5)
+#define TXT_MOUSE_X2           (TXT_MOUSE_BASE + 6)
 #define TXT_MAX_MOUSE_BUTTONS  16
 
 #define TXT_KEY_TO_MOUSE_BUTTON(x)                                        \

--- a/textscreen/txt_main.h
+++ b/textscreen/txt_main.h
@@ -41,8 +41,8 @@
 #define TXT_MOUSE_LEFT         (TXT_MOUSE_BASE + 0)
 #define TXT_MOUSE_RIGHT        (TXT_MOUSE_BASE + 1)
 #define TXT_MOUSE_MIDDLE       (TXT_MOUSE_BASE + 2)
-#define TXT_MOUSE_SCROLLUP     (TXT_MOUSE_BASE + 3)
-#define TXT_MOUSE_SCROLLDOWN   (TXT_MOUSE_BASE + 4)
+#define TXT_MOUSE_SCROLLUP     (TXT_MOUSE_BASE + 6)
+#define TXT_MOUSE_SCROLLDOWN   (TXT_MOUSE_BASE + 7)
 #define TXT_MAX_MOUSE_BUTTONS  16
 
 #define TXT_KEY_TO_MOUSE_BUTTON(x)                                        \

--- a/textscreen/txt_sdl.c
+++ b/textscreen/txt_sdl.c
@@ -567,7 +567,7 @@ static int SDLButtonToTXTButton(int button)
         case SDL_BUTTON_MIDDLE:
             return TXT_MOUSE_MIDDLE;
         default:
-            return TXT_MOUSE_BASE + button - 1;
+            return TXT_MOUSE_BASE + button + 1;
     }
 }
 


### PR DESCRIPTION
The MapMouseWheelToButtons() function now uses Button 6 and 7 instead of 3 and 4 in order not to be in conflict with the extra mouse buttons.
Fixes https://github.com/chocolate-doom/chocolate-doom/issues/1344